### PR TITLE
2 changes made. Firstly found a bug in clBuildProgram (in program.go) associated with targeting one device (not several) and changed the num_devices passed accordingly. Secondly added CreateBufferFloat32 and CreateEmptyBufferFloat32 to context.go.

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -131,8 +131,17 @@ func (ctx *Context) CreateEmptyBuffer(flags MemFlag, size int) (*MemObject, erro
 	return ctx.CreateBufferUnsafe(flags, size, nil)
 }
 
+func (ctx *Context) CreateEmptyBufferFloat32(flags MemFlag, size int) (*MemObject, error) {
+	return ctx.CreateBufferUnsafe(flags, 4*size, nil)
+}
+
 func (ctx *Context) CreateBuffer(flags MemFlag, data []byte) (*MemObject, error) {
 	return ctx.CreateBufferUnsafe(flags, len(data), unsafe.Pointer(&data[0]))
+}
+
+//float64
+func (ctx *Context) CreateBufferFloat32(flags MemFlag, data []float32) (*MemObject, error) {
+	return ctx.CreateBufferUnsafe(flags, 4*len(data), unsafe.Pointer(&data[0]))
 }
 
 func (ctx *Context) CreateUserEvent() (*Event, error) {

--- a/cl/program.go
+++ b/cl/program.go
@@ -51,7 +51,7 @@ func (p *Program) BuildProgram(devices []*Device, options string) error {
 	}
 	var deviceList []C.cl_device_id
 	var deviceListPtr *C.cl_device_id
-	numDevices := C.cl_uint(0)
+	numDevices := C.cl_uint(len(devices))
 	if devices != nil && len(devices) > 0 {
 		deviceList = buildDeviceIdList(devices)
 		deviceListPtr = &deviceList[0]


### PR DESCRIPTION
Changed the num_devices being passed to clBuildProgram, since this should correspond to the number of devices in device list but was previously statically set to 0.

Added CreateBufferFloat32 and CreateEmptyBufferFloat32 to context.go. This was useful for my project here: https://github.com/BeauJoh/opencldemos where converting an array of floats to byte is either painful at best (as a go programmer shouldnt have to use the unsafe package) or inefficient (using iteration followed by conversion and store). The naming convention of these new functions follows the convention of the SetArg extensions (SetArgBuffer, SetArgUint32, SetArgFloat32 etc) found in the kernel.go file. In the future other data types should be supported (int32,uint32 and 64 equivients). If these changes get merged back into samuel(s) project his documentation should also be adjusted.
